### PR TITLE
Simple Docker image of WWW SQL Designer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM tutum/apache-php
+RUN apt-get update && apt-get install -yq git && rm -rf /var/lib/apt/lists/*
+RUN rm -fr /app
+ADD . /app


### PR DESCRIPTION
so this is a very simple Dockerfile to run WWW SQL Designer quickly

Here is the result

https://hub.docker.com/r/pywebdesign/wwwsqldesigner/

Run it with:

```docker run -p 80:80 pywebdesign/wwwsqldesigner```

and check localhost:80 to have a fully working sqldesigner setup

Or simply build it for yourself with the Dockerfile