### PR TITLE
Revision to postgresql schema generator

### DIFF
--- a/db/postgresql/output.xsl
+++ b/db/postgresql/output.xsl
@@ -26,14 +26,14 @@
 
 <!-- tables -->
 	<xsl:for-each select="table">
-		<xsl:text>CREATE TABLE "</xsl:text>
+		<xsl:text>CREATE TABLE </xsl:text>
 		<xsl:value-of select="@name" />
-		<xsl:text>" (
+		<xsl:text> (
 </xsl:text>
 		<xsl:for-each select="row">
-			<xsl:text>"</xsl:text>
+			<xsl:text> </xsl:text>
 			<xsl:value-of select="@name" />
-			<xsl:text>" </xsl:text>
+			<xsl:text> </xsl:text>
 
             <xsl:choose>
                 <xsl:when test="@autoincrement = 1">
@@ -43,23 +43,23 @@
                     column with nextval(). see:
                     http://www.postgresql.org/docs/current/static/datatype-numeric.html#DATATYPE-SERIAL
                     -->
-                    <xsl:text> SERIAL</xsl:text>
+                    <xsl:text>SERIAL</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
                     <xsl:value-of select="datatype" />
                 </xsl:otherwise>
             </xsl:choose>
-			<xsl:text> </xsl:text>
+			<xsl:text></xsl:text>
 			
 			<xsl:if test="@null = 0">
-				<xsl:text>NOT NULL </xsl:text>
+				<xsl:text> NOT NULL</xsl:text>
 			</xsl:if> 
 			
 			<xsl:if test="default">
                 <xsl:if test=" default != 'NULL' ">
-                    <xsl:text>DEFAULT </xsl:text>
+                    <xsl:text> DEFAULT </xsl:text>
                     <xsl:value-of select="default" />
-                    <xsl:text> </xsl:text>
+                    <xsl:text></xsl:text>
                 </xsl:if>
 			</xsl:if>
 
@@ -75,10 +75,21 @@
 			</xsl:if> 
 		</xsl:for-each>
 		
+<xsl:text>
+);
+</xsl:text>
+<xsl:text>
+
+</xsl:text>
 <!-- keys -->
 		<xsl:for-each select="key">
-			<xsl:text>,
-</xsl:text>
+			<xsl:text>ALTER TABLE </xsl:text>
+            <xsl:text></xsl:text>
+			<xsl:value-of select="../@name" />
+			<xsl:text> </xsl:text>
+            <xsl:text>ADD CONSTRAINT </xsl:text>
+			<xsl:value-of select="../@name" />
+			<xsl:text>_pkey </xsl:text>
 			<xsl:choose>
 				<xsl:when test="@type = 'PRIMARY'">PRIMARY KEY (</xsl:when>
 				<xsl:when test="@type = 'UNIQUE'">UNIQUE (</xsl:when>
@@ -86,18 +97,38 @@
 			</xsl:choose>
 			
 			<xsl:for-each select="part">
-				<xsl:text>"</xsl:text><xsl:value-of select="." /><xsl:text>"</xsl:text>
+				<xsl:text></xsl:text><xsl:value-of select="." /><xsl:text></xsl:text>
 				<xsl:if test="not (position() = last())">
 					<xsl:text>, </xsl:text>
 				</xsl:if>
 			</xsl:for-each>
-			<xsl:text>)</xsl:text>
+			<xsl:text>);
+</xsl:text>
 			
 		</xsl:for-each>
-		
-		<xsl:text>
-);
+
+
+<!-- fk -->
+	<xsl:for-each select="row">
+		<xsl:for-each select="relation">
+			<xsl:text>ALTER TABLE </xsl:text>
+			<xsl:value-of select="../../@name" />
+			<xsl:text> ADD CONSTRAINT </xsl:text>
+			<xsl:value-of select="../../@name" />
+			<xsl:text>_</xsl:text>
+			<xsl:value-of select="../@name" />
+			<xsl:text>_fkey</xsl:text>
+			<xsl:text> FOREIGN KEY (</xsl:text>
+			<xsl:value-of select="../@name" />
+			<xsl:text>) REFERENCES </xsl:text>
+			<xsl:value-of select="@table" />
+			<xsl:text>(</xsl:text>
+			<xsl:value-of select="@row" />
+			<xsl:text>);
 </xsl:text>
+		</xsl:for-each>
+	</xsl:for-each>
+
 
 		<xsl:if test="comment">
             <xsl:text>COMMENT ON TABLE "</xsl:text>
@@ -132,24 +163,6 @@
 
 		<xsl:text>
 </xsl:text>
-	</xsl:for-each>
-
-<!-- fk -->
-	<xsl:for-each select="table">
-		<xsl:for-each select="row">
-			<xsl:for-each select="relation">
-				<xsl:text>ALTER TABLE "</xsl:text>
-				<xsl:value-of select="../../@name" />
-				<xsl:text>" ADD FOREIGN KEY ("</xsl:text>
-				<xsl:value-of select="../@name" />
-				<xsl:text>") REFERENCES "</xsl:text>
-				<xsl:value-of select="@table" />
-				<xsl:text>" ("</xsl:text>
-				<xsl:value-of select="@row" />
-				<xsl:text>");
-</xsl:text>
-			</xsl:for-each>
-		</xsl:for-each>
 	</xsl:for-each>
 
 </xsl:template>


### PR DESCRIPTION
This modification makes the schema format more in-line with good practice for postgresql table schema writing. It also makes it work with some tools that read postgresql schemas to generate code, and need the schema to be a certain format (i.e. SQLBoiler for golang). Check out the results at [pg.aptsy.com](http://pg.aptsy.com)