### PR TITLE
Change Serial to Big Serial for IDs

### DIFF
--- a/db/postgresql/output.xsl
+++ b/db/postgresql/output.xsl
@@ -37,13 +37,13 @@
 
             <xsl:choose>
                 <xsl:when test="@autoincrement = 1">
-                    <!-- use postgresql SERIAL shortcut for columns marked as
+                    <!-- use postgresql BIGSERIAL shortcut for columns marked as
                     auto-increment. this creates integer column,
                     corresponding sequence, and default expression for the
                     column with nextval(). see:
                     http://www.postgresql.org/docs/current/static/datatype-numeric.html#DATATYPE-SERIAL
                     -->
-                    <xsl:text>SERIAL</xsl:text>
+                    <xsl:text>BIGSERIAL</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
                     <xsl:value-of select="datatype" />


### PR DESCRIPTION
This will ensure the ID never exceeds the max size. With Serial, the DB can only handle 2 billion rows, which is not that much for a db. By switching to Big Serial, there is no longer any reason to worry about the limit being reached. All for the small cost of using an additional 4bytes per ID.

[See this article](https://hashrocket.com/blog/posts/running-out-of-ids)