### PR TITLE
Adding "Export SVG" button

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,6 +182,7 @@
 							</div>
 							<hr/>
 							<input type="button" id="clientsql" />
+							<input type="button" id="exportsvg" />
 						</fieldset>
 					</td>
 					<td style="width:40%">

--- a/locale/en.xml
+++ b/locale/en.xml
@@ -82,6 +82,7 @@
 	<string name="dropboxload">Load from Dropbox</string>
 	<string name="dropboxlist">List from Dropbox</string>
 	<string name="clientsql">Generate SQL</string>
+	<string name="exportsvg">Export SVG</string>
 	<string name="backendlabel">Server backend:</string>
 	<string name="serversave">Save</string>
 	<string name="quicksave">Quicksave</string>

--- a/locale/pt_BR.xml
+++ b/locale/pt_BR.xml
@@ -75,6 +75,7 @@
 	<string name="clientsave">Salvar XML</string>
 	<string name="clientload">Carregar XML</string>
 	<string name="clientsql">Gerar SQL</string>
+	<string name="exportsvg">Exportar SVG</string>
 	<string name="backendlabel"> Parâmetros do Servidor:</string>
 	<string name="serversave">Salvar</string>
 	<string name="serverload">Carregar</string>


### PR DESCRIPTION
This is a very basic implementation of SVG export.

It looks into DOM elements to figure out the positions and dimensions,
and then re-creates the tables as plain SVG <rect> and <text>.

Works fine on both Firefox and Chrome.

Known issues:

* The positions are incorrect if the browser has some zoom applied. In
fact, the display is already incorrect in the browser itself (the SVG
paths are not correctly aligned with the elements).
* Rounded corners are not supported. Implementing that (properly) would
require SVG clipping or some extra tricks. Not worth the extra trouble
for now.
* The borders are 2-pixel wide because otherwise they would not align to
the pixel grid (1-pixel border would cover two half pixels).
* There are no translations for other languages.

Related issues:

* https://github.com/ondras/wwwsqldesigner/issues/131
* https://github.com/ondras/wwwsqldesigner/issues/132