### PR TITLE
Added comment indicators for tables and fields

### DIFF
--- a/js/row.js
+++ b/js/row.js
@@ -191,6 +191,7 @@ SQL.Row.prototype.expand = function() {
 	this.buildEdit();
 	this.load();
 	this.redraw();
+	this.dom.container.classList.add('expanded');
 	this.dom.name.focus();
 	this.dom.name.select();
 }
@@ -198,6 +199,7 @@ SQL.Row.prototype.expand = function() {
 SQL.Row.prototype.collapse = function() {
 	if (!this.expanded) { return; }
 	this.expanded = false;
+	this.dom.container.classList.remove('expanded');
 
 	var data = {
 		type: this.dom.type.selectedIndex,

--- a/js/table.js
+++ b/js/table.js
@@ -26,8 +26,6 @@ SQL.Table.prototype._build = function() {
 	var tr = OZ.DOM.elm("tr");
 	this.dom.title = OZ.DOM.elm("td", {className:"title", colSpan:2});
 
-	console.log(this.getComment());
-	
 	OZ.DOM.append(
 		[this.dom.container, this.dom.content],
 		[this.dom.content, thead],

--- a/js/table.js
+++ b/js/table.js
@@ -25,6 +25,8 @@ SQL.Table.prototype._build = function() {
 	var thead = OZ.DOM.elm("thead");
 	var tr = OZ.DOM.elm("tr");
 	this.dom.title = OZ.DOM.elm("td", {className:"title", colSpan:2});
+
+	console.log(this.getComment());
 	
 	OZ.DOM.append(
 		[this.dom.container, this.dom.content],

--- a/styles/style.css
+++ b/styles/style.css
@@ -145,6 +145,34 @@ body {
 	display: inline-block;
 }
 
+.table thead td[title]:after{
+	content: '';
+	position: absolute;
+	top: 0;
+	right: 0;
+	border-color: royalblue;
+	border-style: solid;
+	border-width: 5px;
+	border-bottom-color: transparent;
+	border-left-color: transparent;
+}
+
+.table tbody tr {
+	position: relative;
+}
+
+.table tbody[title]:not(.expanded):not([title=""]) tr:after{
+	content: '';
+	position: absolute;
+	top: 0;
+	right: 0;
+	border-color: royalblue;
+	border-style: solid;
+	border-width: 5px;
+	border-bottom-color: transparent;
+	border-left-color: transparent;
+}
+
 .primary {
 	font-weight: bold;
 }

--- a/styles/style.css
+++ b/styles/style.css
@@ -145,7 +145,7 @@ body {
 	display: inline-block;
 }
 
-.table thead td[title]:after{
+.table thead td[title]:not([title=""]):after{
 	content: '';
 	position: absolute;
 	top: 0;

--- a/styles/style.css
+++ b/styles/style.css
@@ -157,11 +157,11 @@ body {
 	border-left-color: transparent;
 }
 
-.table tbody tr {
+.table tbody td {
 	position: relative;
 }
 
-.table tbody[title]:not(.expanded):not([title=""]) tr:after{
+.table tbody[title]:not(.expanded):not([title=""]) td:last-child:after{
 	content: '';
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
A little blue indicator has been added using CSS to show what tables and fields contain comments.

Also a class expanded has been added for fields to not display the indicator while the field is open.