### PR TITLE
[ja] Fix typo

### DIFF
--- a/locale/ja.xml
+++ b/locale/ja.xml
@@ -71,7 +71,7 @@
 	<string name="empty">下の入出力欄にXMLデータを貼りつけてから実行してください。</string>
 	<string name="client">クライアント</string>
 	<string name="server">サーバ</string>
-	<string name="output">入力出欄</string>
+	<string name="output">入出力欄</string>
 	<string name="clientsave">XMLを出力</string>
 	<string name="clientload">XMLを読込</string>
 	<string name="clientsql">SQLを生成</string>


### PR DESCRIPTION
The Japanese translation of "Input / Output" is "入出力", not "入力出".

\# "欄" means "field".