### PR TITLE
Generate SQL - Postgres - Move FKey creation to end of script

### DIFF
--- a/db/postgresql/output.xsl
+++ b/db/postgresql/output.xsl
@@ -107,29 +107,6 @@
 			
 		</xsl:for-each>
 
-
-<!-- fk -->
-	<xsl:for-each select="row">
-		<xsl:for-each select="relation">
-			<xsl:text>ALTER TABLE </xsl:text>
-			<xsl:value-of select="../../@name" />
-			<xsl:text> ADD CONSTRAINT </xsl:text>
-			<xsl:value-of select="../../@name" />
-			<xsl:text>_</xsl:text>
-			<xsl:value-of select="../@name" />
-			<xsl:text>_fkey</xsl:text>
-			<xsl:text> FOREIGN KEY (</xsl:text>
-			<xsl:value-of select="../@name" />
-			<xsl:text>) REFERENCES </xsl:text>
-			<xsl:value-of select="@table" />
-			<xsl:text>(</xsl:text>
-			<xsl:value-of select="@row" />
-			<xsl:text>);
-</xsl:text>
-		</xsl:for-each>
-	</xsl:for-each>
-
-
 		<xsl:if test="comment">
             <xsl:text>COMMENT ON TABLE "</xsl:text>
             <xsl:value-of select="@name"/>
@@ -164,6 +141,30 @@
 		<xsl:text>
 </xsl:text>
 	</xsl:for-each>
+
+<!-- tables -->
+<xsl:for-each select="table">
+	<!-- fk -->
+	<xsl:for-each select="row">
+		<xsl:for-each select="relation">
+			<xsl:text>ALTER TABLE </xsl:text>
+			<xsl:value-of select="../../@name" />
+			<xsl:text> ADD CONSTRAINT </xsl:text>
+			<xsl:value-of select="../../@name" />
+			<xsl:text>_</xsl:text>
+			<xsl:value-of select="../@name" />
+			<xsl:text>_fkey</xsl:text>
+			<xsl:text> FOREIGN KEY (</xsl:text>
+			<xsl:value-of select="../@name" />
+			<xsl:text>) REFERENCES </xsl:text>
+			<xsl:value-of select="@table" />
+			<xsl:text>(</xsl:text>
+			<xsl:value-of select="@row" />
+			<xsl:text>);
+</xsl:text>
+		</xsl:for-each>
+	</xsl:for-each>
+</xsl:for-each>
 
 </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
So far if FKeys were present, the generated SQL for Postgres failed to execute because of the wrong ordering (creation of FKeys before creation of referenced tables).  