### PR TITLE
upgrade dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+.dockerignore
+.gitignore
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM tutum/apache-php
-RUN apt-get update && apt-get install -yq git && rm -rf /var/lib/apt/lists/*
-RUN rm -fr /app
-ADD . /app
+FROM php:5-apache
+
+EXPOSE 80
+
+WORKDIR /var/www/html
+
+USER www-data
+
+COPY . .


### PR DESCRIPTION
`tutum/apache-php` is deprecated. It's better to use the official php apache image.