### PR TITLE
Minor change: Update Postgres datatypes, add JSON and JSONB

### DIFF
--- a/db/postgresql/datatypes.xml
+++ b/db/postgresql/datatypes.xml
@@ -37,5 +37,7 @@
 		<type label="Inet Host Addr" length="0" sql="INET" quote="'" />
 		<type label="Inet CIDR Addr" length="0" sql="CIDR" quote="'" />
 		<type label="Geometry" length="0" sql="GEOMETRY" quote="'" />
+        <type label="JSON" length="0" sql="JSON" quote="'" />
+        <type label="JSONB" length="0" sql="JSONB" quote="'" />
 	</group>
 </datatypes>


### PR DESCRIPTION
Issue is currently open in #240. Enormously small changes, two additions to the `db/postgresql/datatypes.xml`.

More information regarding these field types can be found in the Postgresql 13 Docs -> Data Types -> JSON Types, located here: https://www.postgresql.org/docs/13/datatype-json.html

Also, in the issue (#240), a user mentions missing json fields for MySQL, which they have add locally. I am not familiar with MySQL, nor am I aware if a PR has already been made for MySQL, but I can append any additions for missing field types in this PR as well.

---------

On a side note, there is not enough appreciation in the world for this wonderful tool you've created @ondras, I have been using it for years and it is an essential part of my toolkit :) 