### PR TITLE
Fix requirement for using root in docker container to use port 80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM php:5-apache
 
-EXPOSE 80
+RUN sed -i 's/Listen 80/Listen ${PORT}/' /etc/apache2/ports.conf
+
+ENV PORT=8080
+
+EXPOSE 8080
 
 WORKDIR /var/www/html
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you wish to support this project, <a href='https://www.paypal.com/cgi-bin/web
 ## Docker Installation:
 
 1. Build `docker build -t wwwsqldesigner .`
-2. Run   `docker run -d -p 8080:80 wwwsqldesigner`
+2. Run   `docker run -d -p 8080:8080 wwwsqldesigner`
 3. Visit http://127.0.0.1:8080
 
 # News


### PR DESCRIPTION
Tiny pull request to remove Docker image's dependency on running apache inside the container as root for access to port 80.

This PR also allows to change the port easily, either by modifying the Dockerfile or providing a `PORT` env variable in the `docker run` command.

README.md also updated to reflect this change for seamless start.