### PR TITLE
Changing Apache web server for busybox light web sever

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
 FROM busybox:1.37
 
-RUN adduser -D static
-
-# USER static
-# WORKDIR /home/static
+WORKDIR /var/www/html
 
 USER www-data
-WORKDIR /var/www/html
 
 COPY . .
 
-# Run BusyBox httpd
+# Run BusyBox httpd on port 8080
 CMD ["busybox", "httpd", "-f", "-v", "-p", "8080"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM php:5-apache
+FROM busybox:1.37
 
-RUN sed -i 's/Listen 80/Listen ${PORT}/' /etc/apache2/ports.conf
+RUN adduser -D static
 
-ENV PORT=8080
-
-EXPOSE 8080
-
-WORKDIR /var/www/html
+# USER static
+# WORKDIR /home/static
 
 USER www-data
+WORKDIR /var/www/html
 
 COPY . .
+
+# Run BusyBox httpd
+CMD ["busybox", "httpd", "-f", "-v", "-p", "8080"]


### PR DESCRIPTION
Replace the `php:5-apache` with the latest `busybox:1.37`. This reduce the image size:

**Before**
```
$ sudo docker images -a
REPOSITORY                  TAG             IMAGE ID       CREATED             SIZE
wwwsqldesigner              latest          eec345cebef1   41 minutes ago      356MB
```

**After**
```
$ sudo docker images -a                         
REPOSITORY                  TAG             IMAGE ID       CREATED             SIZE
wwwsqldesigner              latest          13f1d14563f3   About a minute ago   5.12MB
```

